### PR TITLE
fix: correctly map several media types which are the same in before/after but has wildcards

### DIFF
--- a/test/bugs.test.ts
+++ b/test/bugs.test.ts
@@ -27,6 +27,9 @@ import changeToNothingClassificationAfter from './helper/resources/change-to-not
 import spearedParamsBefore from './helper/resources/speared-parameters/before.json'
 import spearedParamsAfter from './helper/resources/speared-parameters/after.json'
 
+import wildcardContentSchemaMediaTypeCombinedWithSpecificMediaTypeBefore from './helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/before.json'
+import wildcardContentSchemaMediaTypeCombinedWithSpecificMediaTypeAfter from './helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/after.json'
+
 import { diffsMatcher } from './helper/matchers'
 import { TEST_DIFF_FLAG, TEST_ORIGINS_FLAG } from './helper'
 import { JSON_SCHEMA_NODE_SYNTHETIC_TYPE_NOTHING } from '@netcracker/qubership-apihub-api-unifier'
@@ -97,16 +100,7 @@ describe('Real Data', () => {
     const after: any = infinityAfter
     const { diffs } = apiDiff(before, after, OPTIONS)
     const responseContentPath = ['paths', '/api/v1/dictionaries/dictionary/item', 'get', 'responses', '200', 'content']
-    expect(diffs).toEqual(diffsMatcher([
-      expect.objectContaining({
-        beforeDeclarationPaths: [[...responseContentPath, '*/*']],
-        afterDeclarationPaths: [[...responseContentPath, 'application/json']],
-        action: DiffAction.rename,
-        beforeKey: '*/*',
-        afterKey: 'application/json',
-        type: nonBreaking,
-        scope: 'response',
-      }),
+    expect(diffs).toEqual(diffsMatcher([      
       expect.objectContaining({
         afterDeclarationPaths: [['components', 'schemas', 'DictionaryItem', 'x-entity']],
         afterValue: 'DictionaryItem',
@@ -210,10 +204,26 @@ describe('Real Data', () => {
       }),
     ]))
   })
-  it('spered parameters', () => {
+
+  it('speared parameters', () => {
     const before: any = spearedParamsBefore
     const after: any = spearedParamsAfter
     const { diffs } = apiDiff(before, after, OPTIONS)
     expect(diffs).toBeEmpty()
+  })
+
+  it('wildcard content schema media type in combination with specific media type', () => {
+    const before: any = wildcardContentSchemaMediaTypeCombinedWithSpecificMediaTypeBefore
+    const after: any = wildcardContentSchemaMediaTypeCombinedWithSpecificMediaTypeAfter
+    const { diffs } = apiDiff(before, after, OPTIONS)
+    
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeDeclarationPaths: [['servers', 0, 'url']],
+        afterDeclarationPaths: [['servers', 0, 'url']],
+        type: annotation,
+      }),
+    ]))
   })
 })

--- a/test/helper/resources/ref-with-array-to-self/after.json
+++ b/test/helper/resources/ref-with-array-to-self/after.json
@@ -7,7 +7,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {
+              "*/*": {
                 "schema": {
                   "type": "array",
                   "items": {

--- a/test/helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/after.json
+++ b/test/helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/after.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "url": "http://config-server.cbss-kue-coe-dv.cl.local:1111",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/path1": {
+      "get": {        
+        "operationId": "retrieve_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/test/helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/before.json
+++ b/test/helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/before.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "url": "http://config-server:1111",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/path1": {
+      "get": {
+        "operationId": "retrieve_1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "byte"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/test/openapi.contentMediaTypeMapping.test.ts
+++ b/test/openapi.contentMediaTypeMapping.test.ts
@@ -1,0 +1,354 @@
+import { contentMediaTypeMappingResolver } from '../src/openapi/openapi3.mapping'
+import { DiffAction } from '../src'
+
+// Mock context for testing
+const mockContext = {} as any
+
+describe('Content Media Type Mapping', () => {
+  
+  describe('Exact Matching Cases', () => {
+    it('should map identical media types', () => {
+      const before = { 'application/json': {} }
+      const after = { 'application/json': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 'application/json': 'application/json' }
+      })
+    })
+
+    it('should map multiple exact matches', () => {
+      const before = { 
+        'application/json': {},
+        'text/*': {},
+        '*/*': {}
+      }
+      const after = { 
+        'application/json': {},
+        'text/*': {},
+        '*/*': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 
+          'application/json': 'application/json',
+          'text/*': 'text/*',
+          '*/*': '*/*'
+        }
+      })
+    })
+
+    it('should match media types ignoring parameters', () => {
+      const before = { 'application/json; charset=utf-8': {} }
+      const after = { 'application/json; charset=iso-8859-1': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 'application/json; charset=utf-8': 'application/json; charset=iso-8859-1' }
+      })
+    })
+
+    it('should prefer exact matches over wildcard compatibility', () => {
+      const before = { 
+        'application/json': {},
+        '*/*': {}
+      }
+      const after = { 
+        'application/json': {},
+        'text/xml': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 
+          'application/json': 'application/json',
+          '*/*': 'text/xml'
+        }
+      })
+    })
+  })
+
+  describe('Wildcard Fallback Cases', () => {
+    it('should map wildcard to specific when exactly one unmapped item on each side', () => {
+      const before = { '*/*': {} }
+      const after = { 'application/json': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { '*/*': 'application/json' }
+      })
+    })    
+
+    it('should map partial wildcards', () => {
+      const before = { 'application/*': {} }
+      const after = { 'application/json': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 'application/*': 'application/json' }
+      })
+    })
+
+    it('should map wildcard to wildcard', () => {
+      const before = { '*/*': {} }
+      const after = { 'application/*': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { '*/*': 'application/*' }
+      })
+    })
+
+    it('should map wildcard fallback after exact matches', () => {
+      const before = { 
+        'application/json': {},
+        '*/*': {}
+      }
+      const after = { 
+        'application/json': {},
+        'text/xml': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 
+          'application/json': 'application/json',
+          '*/*': 'text/xml'
+        }
+      })
+    })
+  })
+
+  describe('No Mapping Cases', () => {
+    it('should mark completely different types as added/removed', () => {
+      const before = { 'application/json': {} }
+      const after = { 'text/xml': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['text/xml'],
+        removed: ['application/json'],
+        mapped: {}
+      })
+    })    
+
+    it('should not map incompatible wildcards when multiple unmapped', () => {
+      const before = { 
+        'application/*': {},
+        'text/xml': {}
+      }
+      const after = { 
+        '*/*': {},
+        'video/mp4': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['*/*', 'video/mp4'],
+        removed: ['application/*', 'text/xml'],
+        mapped: {}
+      })
+    })
+
+    it('should not map incompatible types even with single unmapped items', () => {
+      const before = { 'application/json': {} }
+      const after = { 'text/*': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['text/*'],
+        removed: ['application/json'],
+        mapped: {}
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty before object', () => {
+      const before = {}
+      const after = { 'application/json': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['application/json'],
+        removed: [],
+        mapped: {}
+      })
+    })
+
+    it('should handle empty after object', () => {
+      const before = { 'application/json': {} }
+      const after = {}
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: ['application/json'],
+        mapped: {}
+      })
+    })
+
+    it('should handle both empty objects', () => {
+      const before = {}
+      const after = {}
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: {}
+      })
+    })
+
+    it('should handle malformed media types gracefully', () => {
+      const before = { 'invalid-media-type': {} }
+      const after = { 'also-invalid': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['also-invalid'],
+        removed: ['invalid-media-type'],
+        mapped: {}
+      })
+    })
+
+    it('should handle media types with multiple parameters', () => {
+      const before = { 'application/json; charset=utf-8; boundary=something': {} }
+      const after = { 'application/json; charset=iso-8859-1; version=1.0': {} }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 
+          'application/json; charset=utf-8; boundary=something': 'application/json; charset=iso-8859-1; version=1.0' 
+        }
+      })
+    })
+  })
+
+  describe('Complex Scenarios', () => {
+    it('should handle mixed exact matches and wildcard fallback', () => {
+      const before = { 
+        'application/json': {},
+        'text/*': {},
+        '*/*': {}
+      }
+      const after = { 
+        'application/json': {},
+        'text/*': {},
+        'image/png': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 
+          'application/json': 'application/json',
+          'text/*': 'text/*',
+          '*/*': 'image/png'
+        }
+      })
+    })
+
+    it('should handle exact matches with remaining incompatible types', () => {
+      const before = { 
+        'application/json': {},
+        'text/xml': {},
+        'application/pdf': {}
+      }
+      const after = { 
+        'application/json': {},
+        'image/png': {},
+        'video/mp4': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['image/png', 'video/mp4'],
+        removed: ['text/xml', 'application/pdf'],
+        mapped: { 'application/json': 'application/json' }
+      })
+    })
+
+    it('should prioritize exact matches over potential wildcard matches', () => {
+      const before = { 
+        'application/json': {},
+        'application/*': {}
+      }
+      const after = { 
+        'application/json': {},
+        'application/xml': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: [],
+        removed: [],
+        mapped: { 
+          'application/json': 'application/json',
+          'application/*': 'application/xml'
+        }
+      })
+    })
+
+    it('should handle asymmetric counts with wildcard fallback', () => {
+      const before = { 
+        'application/json': {},
+        'text/xml': {},
+        '*/*': {}
+      }
+      const after = { 
+        'application/json': {},
+        'image/png': {}
+      }
+      
+      const result = contentMediaTypeMappingResolver(before, after, mockContext)
+      
+      expect(result).toEqual({
+        added: ['image/png'],
+        removed: ['text/xml', '*/*'],
+        mapped: { 
+          'application/json': 'application/json'
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
- simplify content schema media type mapping logic:
  - prefer exact matches
  - map wildcard-compatible media type if there's exactly one in before/after
  - return all remaining media types as added/removed correspondingly

- remove media type change from 'Ref with array to self - cycled path' unit test, since it is not really relevant for the cases being tested

- add unit tests for content schema media type mapping

- add unit test with case from the issue https://github.com/Netcracker/qubership-apihub-api-diff/issues/18