### PR TITLE
fix: add compatibility suite tests for OAS 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-api-unifier": "2.0.0",
+    "@netcracker/qubership-apihub-api-unifier": "feature-null-type",
     "@netcracker/qubership-apihub-json-crawl": "1.0.4",
     "fast-equals": "4.0.3"
   },
   "devDependencies": {
-    "@netcracker/qubership-apihub-compatibility-suites": "2.0.3",
+    "@netcracker/qubership-apihub-compatibility-suites": "feature-null-type",
     "@netcracker/qubership-apihub-graphapi": "1.0.8",
     "@netcracker/qubership-apihub-npm-gitflow": "3.1.0",
     "@types/jest": "29.5.11",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-api-unifier": "feature-null-type",
+    "@netcracker/qubership-apihub-api-unifier": "dev",
     "@netcracker/qubership-apihub-json-crawl": "1.0.4",
     "fast-equals": "4.0.3"
   },
   "devDependencies": {
-    "@netcracker/qubership-apihub-compatibility-suites": "feature-null-type",
+    "@netcracker/qubership-apihub-compatibility-suites": "dev",
     "@netcracker/qubership-apihub-graphapi": "1.0.8",
     "@netcracker/qubership-apihub-npm-gitflow": "3.1.0",
     "@types/jest": "29.5.11",

--- a/test/compatibility-suites/openapi/parameters-schema.test.ts
+++ b/test/compatibility-suites/openapi/parameters-schema.test.ts
@@ -12,18 +12,9 @@ const PARAMETERS_SCHEMA_PATH = [
   'schema',
 ]
 
-const PATH_TO_PARAMETERS_SCHEMA31 = [
-  'paths',
-  '/example',
-  'get',
-  'parameters',
-  0,
-  'schema',
-]
-
 describe('Openapi3 Parameters Schema', () => {
   runCommonSchemaTests(SUITE_ID, PARAMETERS_SCHEMA_PATH)
 })
 describe('Openapi31 Parameters Schema', () => {
-  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31)
+  runCommonSchema31Tests(SUITE_ID, PARAMETERS_SCHEMA_PATH)
 })

--- a/test/compatibility-suites/openapi/parameters-schema.test.ts
+++ b/test/compatibility-suites/openapi/parameters-schema.test.ts
@@ -12,7 +12,7 @@ const PARAMETERS_SCHEMA_PATH = [
   'schema',
 ]
 
-const PARAMETERS_SCHEMA31_PATH = [
+const PATH_TO_PARAMETERS_SCHEMA31 = [
   'paths',
   '/example',
   'get',
@@ -25,5 +25,5 @@ describe('Openapi3 Parameters Schema', () => {
   runCommonSchemaTests(SUITE_ID, PARAMETERS_SCHEMA_PATH)
 })
 describe('Openapi31 Parameters Schema', () => {
-  runCommonSchema31Tests(SUITE_ID, PARAMETERS_SCHEMA31_PATH)
+  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31)
 })

--- a/test/compatibility-suites/openapi/parameters-schema.test.ts
+++ b/test/compatibility-suites/openapi/parameters-schema.test.ts
@@ -1,4 +1,5 @@
 import { runCommonSchemaTests } from './templates/schema'
+import { runCommonSchema31Tests } from './templates/schema31'
 
 const SUITE_ID = 'parameters-schema'
 
@@ -11,6 +12,18 @@ const PARAMETERS_SCHEMA_PATH = [
   'schema',
 ]
 
+const PARAMETERS_SCHEMA31_PATH = [
+  'paths',
+  '/example',
+  'get',
+  'parameters',
+  0,
+  'schema',
+]
+
 describe('Openapi3 Parameters Schema', () => {
   runCommonSchemaTests(SUITE_ID, PARAMETERS_SCHEMA_PATH)
+})
+describe('Openapi31 Parameters Schema', () => {
+  runCommonSchema31Tests(SUITE_ID, PARAMETERS_SCHEMA31_PATH)
 })

--- a/test/compatibility-suites/openapi/request-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/request-body-schema.test.ts
@@ -1,4 +1,5 @@
 import { runCommonSchemaTests } from './templates/schema'
+import { runCommonSchema31Tests } from './templates/schema31'
 
 const SUITE_ID = 'request-body-schema'
 
@@ -12,7 +13,20 @@ const REQUEST_SCHEMA_PATH = [
   'schema',
 ]
 
+const PARAMETERS_SCHEMA31_PATH = [
+  'paths',
+  '/example',
+  'post',
+  'requestBody',
+  'content',
+  'application/json',
+  'schema',
+]
+
 describe('Openapi3 Request Body Schema', () => {
   runCommonSchemaTests(SUITE_ID, REQUEST_SCHEMA_PATH)
+})
 
+describe('Openapi31 Request Body Schema', () => {
+  runCommonSchema31Tests(SUITE_ID, PARAMETERS_SCHEMA31_PATH)
 })

--- a/test/compatibility-suites/openapi/request-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/request-body-schema.test.ts
@@ -13,20 +13,10 @@ const REQUEST_SCHEMA_PATH = [
   'schema',
 ]
 
-const PATH_TO_PARAMETERS_SCHEMA31 = [
-  'paths',
-  '/example',
-  'post',
-  'requestBody',
-  'content',
-  'application/json',
-  'schema',
-]
-
 describe('Openapi3 Request Body Schema', () => {
   runCommonSchemaTests(SUITE_ID, REQUEST_SCHEMA_PATH)
 })
 
 describe('Openapi31 Request Body Schema', () => {
-  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31)
+  runCommonSchema31Tests(SUITE_ID, REQUEST_SCHEMA_PATH)
 })

--- a/test/compatibility-suites/openapi/request-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/request-body-schema.test.ts
@@ -13,7 +13,7 @@ const REQUEST_SCHEMA_PATH = [
   'schema',
 ]
 
-const PARAMETERS_SCHEMA31_PATH = [
+const PATH_TO_PARAMETERS_SCHEMA31 = [
   'paths',
   '/example',
   'post',
@@ -28,5 +28,5 @@ describe('Openapi3 Request Body Schema', () => {
 })
 
 describe('Openapi31 Request Body Schema', () => {
-  runCommonSchema31Tests(SUITE_ID, PARAMETERS_SCHEMA31_PATH)
+  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31)
 })

--- a/test/compatibility-suites/openapi/response-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-body-schema.test.ts
@@ -1628,3 +1628,70 @@ describe('Openapi3 ResponseBody.Schema ', () => {
     ]))
   })
 })
+
+const RESPONSE_SCHEMA31_PATH = [
+  'paths',
+  '/example',
+  'post',
+  'responses',
+  '200',
+  'content',
+  'application/json',
+  'schema',
+]
+
+describe('Openapi31 ResponseBody.Schema ', () => {
+  test('Add second type', async () => {
+    const testId = 'add-second-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
+        type: breaking,
+      }),
+    ]))
+  })
+
+  test('Add third type', async () => {
+    const testId = 'add-third-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
+        type: breaking,
+      }),
+    ]))
+  })
+
+  test('Remove second type', async () => {
+    const testId = 'remove-second-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
+        type: nonBreaking,
+      }),
+    ]))
+  })
+
+  test('Remove third type', async () => {
+    const testId = 'remove-third-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
+        type: nonBreaking,
+      }),
+    ]))
+  })
+
+  test('Reorder types', async () => {
+    const testId = 'reorder-types'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result.length).toEqual(0)
+  })
+})

--- a/test/compatibility-suites/openapi/response-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-body-schema.test.ts
@@ -2,7 +2,7 @@ import { compareFiles, compareFilesWithMerge, TEST_DEFAULTS_DECLARATION_PATHS } 
 import { diffsMatcher } from '../../helper/matchers'
 import { annotation, breaking, DiffAction, nonBreaking, risky } from '../../../src'
 import { JSON_SCHEMA_NODE_SYNTHETIC_TYPE_ANY } from '@netcracker/qubership-apihub-api-unifier'
-import { runCommonSchema31Tests } from './templates/schema31'
+import { runCommonResponseSchema31Tests } from './templates/response-schema31'
 
 const SUITE_ID = 'response-body-schema'
 
@@ -138,7 +138,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
           afterDeclarationPaths: TEST_DEFAULTS_DECLARATION_PATHS,
           type: nonBreaking,
         }),
-      ]
+      ],
     ))
   })
 
@@ -305,7 +305,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
         beforeDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option2', 'minLength']],
         afterDeclarationPaths: TEST_DEFAULTS_DECLARATION_PATHS,
         type: breaking,
-      })
+      }),
     ]))
   })
 
@@ -694,7 +694,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
         beforeDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option1', 'minItems']],
         afterDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option1', 'minItems']],
         type: nonBreaking,
-      })
+      }),
     ]))
   })
 
@@ -739,7 +739,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
         beforeDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option1', 'minItems']],
         afterDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option1', 'minItems']],
         type: breaking,
-      })
+      }),
     ]))
   })
 
@@ -1021,7 +1021,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
         beforeDeclarationPaths: TEST_DEFAULTS_DECLARATION_PATHS,
         afterDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option2', 'minProperties']],
         type: nonBreaking,
-      })
+      }),
     ]))
   })
 
@@ -1066,7 +1066,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
         beforeDeclarationPaths: [[...RESPONSE_SCHEMA_PATH, 'properties', 'option2', 'minProperties']],
         afterDeclarationPaths: TEST_DEFAULTS_DECLARATION_PATHS,
         type: breaking,
-      })
+      }),
     ]))
   })
 
@@ -1630,17 +1630,6 @@ describe('Openapi3 ResponseBody.Schema ', () => {
   })
 })
 
-const PATH_TO_PARAMETERS_SCHEMA31 = [
-  'paths',
-  '/example',
-  'post',
-  'responses',
-  '200',
-  'content',
-  'application/json',
-  'schema',
-]
-
 describe('Openapi31 ResponseBody.Schema', () => {
-  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31, true)
+  runCommonResponseSchema31Tests(SUITE_ID, RESPONSE_SCHEMA_PATH)
 })

--- a/test/compatibility-suites/openapi/response-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-body-schema.test.ts
@@ -1641,8 +1641,8 @@ const RESPONSE_SCHEMA31_PATH = [
 ]
 
 describe('Openapi31 ResponseBody.Schema ', () => {
-  test('Add second type', async () => {
-    const testId = 'add-second-type'
+  test('Add union type', async () => {
+    const testId = 'add-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -1653,8 +1653,8 @@ describe('Openapi31 ResponseBody.Schema ', () => {
     ]))
   })
 
-  test('Add third type', async () => {
-    const testId = 'add-third-type'
+  test('Add null to union type', async () => {
+    const testId = 'add-null-to-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -1665,8 +1665,8 @@ describe('Openapi31 ResponseBody.Schema ', () => {
     ]))
   })
 
-  test('Remove second type', async () => {
-    const testId = 'remove-second-type'
+  test('Remove union type', async () => {
+    const testId = 'remove-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -1677,8 +1677,8 @@ describe('Openapi31 ResponseBody.Schema ', () => {
     ]))
   })
 
-  test('Remove third type', async () => {
-    const testId = 'remove-third-type'
+  test('Remove null from union type', async () => {
+    const testId = 'remove-null-from-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -1689,8 +1689,8 @@ describe('Openapi31 ResponseBody.Schema ', () => {
     ]))
   })
 
-  test('Reorder types', async () => {
-    const testId = 'reorder-types'
+  test('Reorder types in union type', async () => {
+    const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result.length).toEqual(0)
   })

--- a/test/compatibility-suites/openapi/response-body-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-body-schema.test.ts
@@ -2,6 +2,7 @@ import { compareFiles, compareFilesWithMerge, TEST_DEFAULTS_DECLARATION_PATHS } 
 import { diffsMatcher } from '../../helper/matchers'
 import { annotation, breaking, DiffAction, nonBreaking, risky } from '../../../src'
 import { JSON_SCHEMA_NODE_SYNTHETIC_TYPE_ANY } from '@netcracker/qubership-apihub-api-unifier'
+import { runCommonSchema31Tests } from './templates/schema31'
 
 const SUITE_ID = 'response-body-schema'
 
@@ -1629,7 +1630,7 @@ describe('Openapi3 ResponseBody.Schema ', () => {
   })
 })
 
-const RESPONSE_SCHEMA31_PATH = [
+const PATH_TO_PARAMETERS_SCHEMA31 = [
   'paths',
   '/example',
   'post',
@@ -1640,58 +1641,6 @@ const RESPONSE_SCHEMA31_PATH = [
   'schema',
 ]
 
-describe('Openapi31 ResponseBody.Schema ', () => {
-  test('Add union type', async () => {
-    const testId = 'add-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.add,
-        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
-        type: breaking,
-      }),
-    ]))
-  })
-
-  test('Add null to union type', async () => {
-    const testId = 'add-null-to-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.add,
-        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
-        type: breaking,
-      }),
-    ]))
-  })
-
-  test('Remove union type', async () => {
-    const testId = 'remove-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.remove,
-        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
-        type: nonBreaking,
-      }),
-    ]))
-  })
-
-  test('Remove null from union type', async () => {
-    const testId = 'remove-null-from-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.remove,
-        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
-        type: nonBreaking,
-      }),
-    ]))
-  })
-
-  test('Reorder types in union type', async () => {
-    const testId = 'reorder-types-in-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result.length).toEqual(0)
-  })
+describe('Openapi31 ResponseBody.Schema', () => {
+  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31, true)
 })

--- a/test/compatibility-suites/openapi/response-headers-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-headers-schema.test.ts
@@ -1,11 +1,11 @@
-import { runCommonSchema31Tests } from './templates/schema31'
+import { runCommonResponseSchema31Tests } from './templates/response-schema31'
 
 const SUITE_ID = 'response-headers-schema'
 
-const PATH_TO_PARAMETERS_SCHEMA31 = [
+const RESPONSE_SCHEMA_PATH = [
   'paths',
-  '/example',
-  'get',
+  '/path1',
+  'post',
   'responses',
   '200',
   'headers',
@@ -14,5 +14,5 @@ const PATH_TO_PARAMETERS_SCHEMA31 = [
 ]
 
 describe('Openapi31 ResponseHeaders.Schema', () => {
-  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31, true)
+  runCommonResponseSchema31Tests(SUITE_ID, RESPONSE_SCHEMA_PATH)
 })

--- a/test/compatibility-suites/openapi/response-headers-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-headers-schema.test.ts
@@ -2,7 +2,7 @@ import { runCommonResponseSchema31Tests } from './templates/response-schema31'
 
 const SUITE_ID = 'response-headers-schema'
 
-const RESPONSE_SCHEMA_PATH = [
+const RESPONSE_HEADERS_SCHEMA_PATH = [
   'paths',
   '/path1',
   'post',
@@ -14,5 +14,5 @@ const RESPONSE_SCHEMA_PATH = [
 ]
 
 describe('Openapi31 ResponseHeaders.Schema', () => {
-  runCommonResponseSchema31Tests(SUITE_ID, RESPONSE_SCHEMA_PATH)
+  runCommonResponseSchema31Tests(SUITE_ID, RESPONSE_HEADERS_SCHEMA_PATH)
 })

--- a/test/compatibility-suites/openapi/response-headers-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-headers-schema.test.ts
@@ -16,8 +16,8 @@ const RESPONSE_SCHEMA31_PATH = [
 ]
 
 describe('Openapi31 ResponseHeaders.Schema ', () => {
-  test('Add second type', async () => {
-    const testId = 'add-second-type'
+  test('Add union type', async () => {
+    const testId = 'add-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -28,8 +28,8 @@ describe('Openapi31 ResponseHeaders.Schema ', () => {
     ]))
   })
 
-  test('Add third type', async () => {
-    const testId = 'add-third-type'
+  test('Add null to union type', async () => {
+    const testId = 'add-null-to-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -40,8 +40,8 @@ describe('Openapi31 ResponseHeaders.Schema ', () => {
     ]))
   })
 
-  test('Remove second type', async () => {
-    const testId = 'remove-second-type'
+  test('Remove union type', async () => {
+    const testId = 'remove-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -52,8 +52,8 @@ describe('Openapi31 ResponseHeaders.Schema ', () => {
     ]))
   })
 
-  test('Remove third type', async () => {
-    const testId = 'remove-third-type'
+  test('Remove null from union type', async () => {
+    const testId = 'remove-null-from-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -64,8 +64,8 @@ describe('Openapi31 ResponseHeaders.Schema ', () => {
     ]))
   })
 
-  test('Reorder types', async () => {
-    const testId = 'reorder-types'
+  test('Reorder types in union type', async () => {
+    const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(SUITE_ID, testId)
     expect(result.length).toEqual(0)
   })

--- a/test/compatibility-suites/openapi/response-headers-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-headers-schema.test.ts
@@ -1,0 +1,72 @@
+import { compareFiles } from '../utils'
+import { diffsMatcher } from '../../helper/matchers'
+import { breaking, DiffAction, nonBreaking } from '../../../src'
+
+const SUITE_ID = 'response-headers-schema'
+
+const RESPONSE_SCHEMA31_PATH = [
+  'paths',
+  '/example',
+  'get',
+  'responses',
+  '200',
+  'headers',
+  'X-Header-1',
+  'schema',
+]
+
+describe('Openapi31 ResponseHeaders.Schema ', () => {
+  test('Add second type', async () => {
+    const testId = 'add-second-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
+        type: breaking,
+      }),
+    ]))
+  })
+
+  test('Add third type', async () => {
+    const testId = 'add-third-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
+        type: breaking,
+      }),
+    ]))
+  })
+
+  test('Remove second type', async () => {
+    const testId = 'remove-second-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
+        type: nonBreaking,
+      }),
+    ]))
+  })
+
+  test('Remove third type', async () => {
+    const testId = 'remove-third-type'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
+        type: nonBreaking,
+      }),
+    ]))
+  })
+
+  test('Reorder types', async () => {
+    const testId = 'reorder-types'
+    const result = await compareFiles(SUITE_ID, testId)
+    expect(result.length).toEqual(0)
+  })
+})

--- a/test/compatibility-suites/openapi/response-headers-schema.test.ts
+++ b/test/compatibility-suites/openapi/response-headers-schema.test.ts
@@ -1,10 +1,8 @@
-import { compareFiles } from '../utils'
-import { diffsMatcher } from '../../helper/matchers'
-import { breaking, DiffAction, nonBreaking } from '../../../src'
+import { runCommonSchema31Tests } from './templates/schema31'
 
 const SUITE_ID = 'response-headers-schema'
 
-const RESPONSE_SCHEMA31_PATH = [
+const PATH_TO_PARAMETERS_SCHEMA31 = [
   'paths',
   '/example',
   'get',
@@ -15,58 +13,6 @@ const RESPONSE_SCHEMA31_PATH = [
   'schema',
 ]
 
-describe('Openapi31 ResponseHeaders.Schema ', () => {
-  test('Add union type', async () => {
-    const testId = 'add-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.add,
-        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
-        type: breaking,
-      }),
-    ]))
-  })
-
-  test('Add null to union type', async () => {
-    const testId = 'add-null-to-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.add,
-        afterDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
-        type: breaking,
-      }),
-    ]))
-  })
-
-  test('Remove union type', async () => {
-    const testId = 'remove-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.remove,
-        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 1]],
-        type: nonBreaking,
-      }),
-    ]))
-  })
-
-  test('Remove null from union type', async () => {
-    const testId = 'remove-null-from-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result).toEqual(diffsMatcher([
-      expect.objectContaining({
-        action: DiffAction.remove,
-        beforeDeclarationPaths: [[...RESPONSE_SCHEMA31_PATH, 'type', 2]],
-        type: nonBreaking,
-      }),
-    ]))
-  })
-
-  test('Reorder types in union type', async () => {
-    const testId = 'reorder-types-in-union-type'
-    const result = await compareFiles(SUITE_ID, testId)
-    expect(result.length).toEqual(0)
-  })
+describe('Openapi31 ResponseHeaders.Schema', () => {
+  runCommonSchema31Tests(SUITE_ID, PATH_TO_PARAMETERS_SCHEMA31, true)
 })

--- a/test/compatibility-suites/openapi/templates/response-schema31.ts
+++ b/test/compatibility-suites/openapi/templates/response-schema31.ts
@@ -55,6 +55,6 @@ export function runCommonResponseSchema31Tests(suiteId: string, commonPath: Json
   test('Reorder types in union type', async () => {
     const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(suiteId, testId)
-    expect(result.length).toEqual(0)
+    expect(result.length).toBeEmpty()
   })
 }

--- a/test/compatibility-suites/openapi/templates/response-schema31.ts
+++ b/test/compatibility-suites/openapi/templates/response-schema31.ts
@@ -55,6 +55,6 @@ export function runCommonResponseSchema31Tests(suiteId: string, commonPath: Json
   test('Reorder types in union type', async () => {
     const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(suiteId, testId)
-    expect(result.length).toBeEmpty()
+    expect(result).toBeEmpty()
   })
 }

--- a/test/compatibility-suites/openapi/templates/response-schema31.ts
+++ b/test/compatibility-suites/openapi/templates/response-schema31.ts
@@ -3,7 +3,7 @@ import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
 import { breaking, DiffAction, nonBreaking } from '../../../../src'
 import { diffsMatcher } from '../../../helper/matchers'
 
-export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): void {
+export function runCommonResponseSchema31Tests(suiteId: string, commonPath: JsonPath): void {
   test('Add union type', async () => {
     const testId = 'add-union-type'
     const result = await compareFiles(suiteId, testId)
@@ -11,7 +11,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.add,
         afterDeclarationPaths: [[...commonPath, 'type', 1]],
-        type: nonBreaking,
+        type: breaking,
       }),
     ]))
   })
@@ -23,7 +23,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.add,
         afterDeclarationPaths: [[...commonPath, 'type', 2]],
-        type: nonBreaking,
+        type: breaking,
       }),
     ]))
   })
@@ -35,7 +35,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.remove,
         beforeDeclarationPaths: [[...commonPath, 'type', 1]],
-        type: breaking,
+        type: nonBreaking,
       }),
     ]))
   })
@@ -47,7 +47,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.remove,
         beforeDeclarationPaths: [[...commonPath, 'type', 2]],
-        type: breaking,
+        type: nonBreaking,
       }),
     ]))
   })

--- a/test/compatibility-suites/openapi/templates/schema31.ts
+++ b/test/compatibility-suites/openapi/templates/schema31.ts
@@ -4,8 +4,8 @@ import { breaking, DiffAction, nonBreaking } from '../../../../src'
 import { diffsMatcher } from '../../../helper/matchers'
 
 export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): void {
-  test('Add second type', async () => {
-    const testId = 'add-second-type'
+  test('Add union type', async () => {
+    const testId = 'add-union-type'
     const result = await compareFiles(suiteId, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -16,8 +16,8 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
     ]))
   })
 
-  test('Add third type', async () => {
-    const testId = 'add-third-type'
+  test('Add null to union type', async () => {
+    const testId = 'add-null-to-union-type'
     const result = await compareFiles(suiteId, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -28,8 +28,8 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
     ]))
   })
 
-  test('Remove second type', async () => {
-    const testId = 'remove-second-type'
+  test('Remove union type', async () => {
+    const testId = 'remove-union-type'
     const result = await compareFiles(suiteId, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -40,8 +40,8 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
     ]))
   })
 
-  test('Remove third type', async () => {
-    const testId = 'remove-third-type'
+  test('Remove null from union type', async () => {
+    const testId = 'remove-null-from-union-type'
     const result = await compareFiles(suiteId, testId)
     expect(result).toEqual(diffsMatcher([
       expect.objectContaining({
@@ -52,8 +52,8 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
     ]))
   })
 
-  test('Reorder types', async () => {
-    const testId = 'reorder-types'
+  test('Reorder types in union type', async () => {
+    const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(suiteId, testId)
     expect(result.length).toEqual(0)
   })

--- a/test/compatibility-suites/openapi/templates/schema31.ts
+++ b/test/compatibility-suites/openapi/templates/schema31.ts
@@ -55,6 +55,6 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
   test('Reorder types in union type', async () => {
     const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(suiteId, testId)
-    expect(result.length).toEqual(0)
+    expect(result.length).toBeEmpty()
   })
 }

--- a/test/compatibility-suites/openapi/templates/schema31.ts
+++ b/test/compatibility-suites/openapi/templates/schema31.ts
@@ -3,7 +3,7 @@ import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
 import { breaking, DiffAction, nonBreaking } from '../../../../src'
 import { diffsMatcher } from '../../../helper/matchers'
 
-export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): void {
+export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath, isResponseSchema = false): void {
   test('Add union type', async () => {
     const testId = 'add-union-type'
     const result = await compareFiles(suiteId, testId)
@@ -11,7 +11,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.add,
         afterDeclarationPaths: [[...commonPath, 'type', 1]],
-        type: nonBreaking,
+        type: isResponseSchema ? breaking : nonBreaking,
       }),
     ]))
   })
@@ -23,7 +23,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.add,
         afterDeclarationPaths: [[...commonPath, 'type', 2]],
-        type: nonBreaking,
+        type: isResponseSchema ? breaking : nonBreaking,
       }),
     ]))
   })
@@ -35,7 +35,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.remove,
         beforeDeclarationPaths: [[...commonPath, 'type', 1]],
-        type: breaking,
+        type: isResponseSchema ? nonBreaking : breaking,
       }),
     ]))
   })
@@ -47,7 +47,7 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
       expect.objectContaining({
         action: DiffAction.remove,
         beforeDeclarationPaths: [[...commonPath, 'type', 2]],
-        type: breaking,
+        type: isResponseSchema ? nonBreaking : breaking,
       }),
     ]))
   })

--- a/test/compatibility-suites/openapi/templates/schema31.ts
+++ b/test/compatibility-suites/openapi/templates/schema31.ts
@@ -55,6 +55,6 @@ export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): v
   test('Reorder types in union type', async () => {
     const testId = 'reorder-types-in-union-type'
     const result = await compareFiles(suiteId, testId)
-    expect(result.length).toBeEmpty()
+    expect(result).toBeEmpty()
   })
 }

--- a/test/compatibility-suites/openapi/templates/schema31.ts
+++ b/test/compatibility-suites/openapi/templates/schema31.ts
@@ -1,0 +1,60 @@
+import { compareFiles } from '../../utils'
+import { JsonPath } from '@netcracker/qubership-apihub-json-crawl'
+import { breaking, DiffAction, nonBreaking } from '../../../../src'
+import { diffsMatcher } from '../../../helper/matchers'
+
+export function runCommonSchema31Tests(suiteId: string, commonPath: JsonPath): void {
+  test('Add second type', async () => {
+    const testId = 'add-second-type'
+    const result = await compareFiles(suiteId, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        afterDeclarationPaths: [[...commonPath, 'type', 1]],
+        type: nonBreaking,
+      }),
+    ]))
+  })
+
+  test('Add third type', async () => {
+    const testId = 'add-third-type'
+    const result = await compareFiles(suiteId, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        afterDeclarationPaths: [[...commonPath, 'type', 2]],
+        type: nonBreaking,
+      }),
+    ]))
+  })
+
+  test('Remove second type', async () => {
+    const testId = 'remove-second-type'
+    const result = await compareFiles(suiteId, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [[...commonPath, 'type', 1]],
+        type: breaking,
+      }),
+    ]))
+  })
+
+  test('Remove third type', async () => {
+    const testId = 'remove-third-type'
+    const result = await compareFiles(suiteId, testId)
+    expect(result).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [[...commonPath, 'type', 2]],
+        type: breaking,
+      }),
+    ]))
+  })
+
+  test('Reorder types', async () => {
+    const testId = 'reorder-types'
+    const result = await compareFiles(suiteId, testId)
+    expect(result.length).toEqual(0)
+  })
+}

--- a/test/helper/resources/array-of-type-is-equivalent-to-anyOf/after.json
+++ b/test/helper/resources/array-of-type-is-equivalent-to-anyOf/after.json
@@ -11,7 +11,7 @@
                 "schema": {
                   "type": [
                     "string",
-                    "null"
+                    "number"
                   ]
                 }
               }

--- a/test/helper/resources/array-of-type-is-equivalent-to-anyOf/after.json
+++ b/test/helper/resources/array-of-type-is-equivalent-to-anyOf/after.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/example": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/helper/resources/array-of-type-is-equivalent-to-anyOf/before.json
+++ b/test/helper/resources/array-of-type-is-equivalent-to-anyOf/before.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/example": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/helper/resources/array-of-type-is-equivalent-to-anyOf/before.json
+++ b/test/helper/resources/array-of-type-is-equivalent-to-anyOf/before.json
@@ -14,7 +14,7 @@
                       "type": "string"
                     },
                     {
-                      "type": "null"
+                      "type": "number"
                     }
                   ]
                 }

--- a/test/helper/resources/null-moves-in-combiner-hierarchy/after.json
+++ b/test/helper/resources/null-moves-in-combiner-hierarchy/after.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/example": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "allOf": [
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/helper/resources/null-moves-in-combiner-hierarchy/before.json
+++ b/test/helper/resources/null-moves-in-combiner-hierarchy/before.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/example": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "allOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    {
+                      "allOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/json-schema.array-of-types.test.ts
+++ b/test/json-schema.array-of-types.test.ts
@@ -1,0 +1,27 @@
+import arrayOfTypeIsEquivalentToAnyOfBefore from './helper/resources/array-of-type-is-equivalent-to-anyOf/before.json'
+import arrayOfTypeIsEquivalentToAnyOfAfter from './helper/resources/array-of-type-is-equivalent-to-anyOf/after.json'
+
+import nullMovesInCombinerHierarchyBefore from './helper/resources/null-moves-in-combiner-hierarchy/before.json'
+import nullMovesInCombinerHierarchyAfter from './helper/resources/null-moves-in-combiner-hierarchy/after.json'
+import { apiDiff, CompareOptions } from '../src'
+import { TEST_DIFF_FLAG, TEST_ORIGINS_FLAG } from './helper'
+import { diffsMatcher } from './helper/matchers'
+
+const OPTIONS: CompareOptions = {
+  originsFlag: TEST_ORIGINS_FLAG,
+  metaKey: TEST_DIFF_FLAG,
+  validate: true,
+  unify: true,
+}
+
+describe('OAS 3.1 array of types', () => {
+  it('array of type is equivalent to anyOf', () => {
+    const { diffs } = apiDiff(arrayOfTypeIsEquivalentToAnyOfBefore, arrayOfTypeIsEquivalentToAnyOfAfter, OPTIONS)
+    expect(diffs).toBeEmpty()
+  })
+
+  it('no changes when "null" moves in combiner hierarchy', () => {
+    const { diffs } = apiDiff(nullMovesInCombinerHierarchyBefore, nullMovesInCombinerHierarchyAfter, OPTIONS)
+    expect(diffs).toBeEmpty()
+  })
+})


### PR DESCRIPTION
Tests: 
1. Tests compatibility suite
2. Array of type is equivalent to anyOf
3. No changes when "null" moves in combiner hierarchy