### PR TITLE
fix: missing enum breaking diff in oneOf combiner in merged document

### DIFF
--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -156,7 +156,7 @@ const cleanUpRecursive = (ctx: NodeContext): NodeContext => {
 }
 
 export const getOrCreateChildDiffAdd = (diffUniquenessCache: EvaluationCacheService, childCtx: CompareContext) => {
-  return diffUniquenessCache.cacheEvaluationResultByFootprint<[unknown, string, CompareScope, typeof DiffAction.add], DiffEntry<DiffAdd>>([childCtx.after.value, buildPathsIdentifier(childCtx.after.declarativePaths), childCtx.scope, DiffAction.add], () => {
+  return diffUniquenessCache.cacheEvaluationResultByFootprint<[unknown, string, CompareScope, typeof DiffAction.add, PropertyKey], DiffEntry<DiffAdd>>([childCtx.after.value, buildPathsIdentifier(childCtx.after.declarativePaths), childCtx.scope, DiffAction.add, childCtx.mergeKey], () => {
     return diffFactory.added(childCtx)
   }, {} as DiffEntry<DiffAdd>, (result, guard) => {
     Object.assign(guard, result)

--- a/test/bugs.test.ts
+++ b/test/bugs.test.ts
@@ -1,4 +1,4 @@
-import { annotation, apiDiff, ClassifierType, CompareOptions, DiffAction, nonBreaking, unclassified } from '../src'
+import { annotation, apiDiff, breaking, ClassifierType, CompareOptions, DiffAction, nonBreaking, unclassified } from '../src'
 import offeringQualificationBefore from './helper/resources/api-v2-offeringqualification-qualification-post/before.json'
 import offeringQualificationAfter from './helper/resources/api-v2-offeringqualification-qualification-post/after.json'
 import readDefaultValueOfRequiredBefore from './helper/resources/read-default-value-of-required-field/before.json'
@@ -29,6 +29,9 @@ import spearedParamsAfter from './helper/resources/speared-parameters/after.json
 
 import wildcardContentSchemaMediaTypeCombinedWithSpecificMediaTypeBefore from './helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/before.json'
 import wildcardContentSchemaMediaTypeCombinedWithSpecificMediaTypeAfter from './helper/resources/wildcard-content-schema-media-type-combined-with-specific-media-type/after.json'
+
+import shouldNotMissRemoveDiffForEnumEntryInOneOfBefore from './helper/resources/should-not-miss-remove-diff-for-enum-entry-in-oneOf/before.json'
+import shouldNotMissRemoveDiffForEnumEntryInOneOfAfter from './helper/resources/should-not-miss-remove-diff-for-enum-entry-in-oneOf/after.json'
 
 import { diffsMatcher } from './helper/matchers'
 import { TEST_DIFF_FLAG, TEST_ORIGINS_FLAG } from './helper'
@@ -224,6 +227,37 @@ describe('Real Data', () => {
         beforeDeclarationPaths: [['servers', 0, 'url']],
         afterDeclarationPaths: [['servers', 0, 'url']],
         type: annotation,
+      }),
+    ]))
+  })
+
+  it('should not miss remove diff for enum entry in oneOf', () => {
+    const before: any = shouldNotMissRemoveDiffForEnumEntryInOneOfBefore
+    const after: any = shouldNotMissRemoveDiffForEnumEntryInOneOfAfter
+    const { merged } = apiDiff(before, after, OPTIONS)
+
+    expect(
+      Object.values((merged as any).paths['/path1'].post.requestBody.content['application/json'].schema.oneOf[1].properties.scope.items.enum[TEST_DIFF_FLAG])
+    ).toEqual(diffsMatcher([
+      expect.objectContaining({
+        beforeValue: 'query',
+        action: DiffAction.remove,
+        type: breaking,
+      }),
+      expect.objectContaining({
+        beforeValue: 'subscription',
+        action: DiffAction.remove,
+        type: breaking,
+      }),
+      expect.objectContaining({
+        afterValue: 'argument',
+        action: DiffAction.add,
+        type: nonBreaking,
+      }),
+      expect.objectContaining({
+        afterValue: 'annotation',
+        action: DiffAction.add,
+        type: nonBreaking,
       }),
     ]))
   })

--- a/test/helper/resources/should-not-miss-remove-diff-for-enum-entry-in-oneOf/after.json
+++ b/test/helper/resources/should-not-miss-remove-diff-for-enum-entry-in-oneOf/after.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "test",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/path1": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "title": "SearchRestParams",
+                    "properties": {
+                      "apiType": {
+                        "type": "string",
+                        "enum": [
+                          "rest"
+                        ]
+                      },
+                      "scope": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "request"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "title": "SearchGQLParams",
+                    "properties": {
+                      "scope": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "argument",
+                            "annotation"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/helper/resources/should-not-miss-remove-diff-for-enum-entry-in-oneOf/before.json
+++ b/test/helper/resources/should-not-miss-remove-diff-for-enum-entry-in-oneOf/before.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "test",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/path1": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "title": "SearchRestParams",
+                    "properties": {
+                      "apiType": {
+                        "type": "string",
+                        "enum": [
+                          "Rest"
+                        ]
+                      },
+                      "scope": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "request"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "title": "SearchGQLParams",
+                    "properties": {
+                      "scope": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "query",
+                            "subscription"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Copied from https://github.com/Netcracker/qubership-apihub-api-diff/pull/39#issuecomment-3306321596

Root cause: ctx.mergeKey is [a part of cached diffEntry](https://github.com/Netcracker/qubership-apihub-api-diff/blob/fd718d88dd114ac14eb79df89be9f3fd0ecdfa97/src/core/diff.ts#L36), but somehow is not a part of the [diffUniquenessCache key](https://github.com/Netcracker/qubership-apihub-api-diff/blob/fd718d88dd114ac14eb79df89be9f3fd0ecdfa97/src/core/compare.ts#L159).


oneOf values are compared combinatorially:
-   SearchRestParams vs SearchGQLParams
-   SearchGQLParams vs SearchRestParams 
-   SearchRestParams vs SearchRestParams
-   SearchGQLParams vs SearchGQLParams

and by the time when the problematic comparison takes place (SearchGQLParams vs SearchGQLParams), the cache is already filled with the DiffEntry<DiffAdd> with the 'argument' value and with the propertyKey that is not correct for this comparison. And this diff eventually will end up overriding the 'subscription' diff [here](https://github.com/Netcracker/qubership-apihub-api-diff/blob/fd718d88dd114ac14eb79df89be9f3fd0ecdfa97/src/core/compare.ts#L322).