### PR TITLE
fix: align classification of changing AsyncAPI operation and messages with classification of changes to REST operation

### DIFF
--- a/src/asyncapi/asyncapi3.rules.ts
+++ b/src/asyncapi/asyncapi3.rules.ts
@@ -274,11 +274,7 @@ export const asyncApi3Rules = (options: AsyncApi3RulesOptions): CompareRules => 
       mapping: firstReferenceKeyMapping,
       '/*': {
         ...messageRules,
-        $: [
-          (ctx) => (ctx.scope === COMPARE_SCOPE_SEND ? nonBreaking : breaking),
-          (ctx) => (ctx.scope === COMPARE_SCOPE_SEND ? breaking : nonBreaking),
-          unclassified,
-        ],
+        $: [nonBreaking, breaking, unclassified],
         ignoreKeyDifference: true
       },
     },

--- a/src/asyncapi/asyncapi3.rules.ts
+++ b/src/asyncapi/asyncapi3.rules.ts
@@ -253,7 +253,7 @@ export const asyncApi3Rules = (options: AsyncApi3RulesOptions): CompareRules => 
 
   // Operation rules factory based on action type
   const operationRules = (isSendAction: boolean): CompareRules => ({
-    $: [unclassified, unclassified, unclassified],
+    $: [nonBreaking, breaking, unclassified],
     [START_NEW_COMPARE_SCOPE_RULE]: isSendAction ? COMPARE_SCOPE_SEND : COMPARE_SCOPE_RECEIVE,
     '/title': { $: allAnnotation },
     '/summary': { $: allAnnotation },
@@ -274,7 +274,7 @@ export const asyncApi3Rules = (options: AsyncApi3RulesOptions): CompareRules => 
       mapping: firstReferenceKeyMapping,
       '/*': {
         ...messageRules,
-        $: [unclassified, unclassified, unclassified],
+        $: [nonBreaking, breaking, unclassified],
         ignoreKeyDifference: true
       },
     },

--- a/src/asyncapi/asyncapi3.rules.ts
+++ b/src/asyncapi/asyncapi3.rules.ts
@@ -253,11 +253,7 @@ export const asyncApi3Rules = (options: AsyncApi3RulesOptions): CompareRules => 
 
   // Operation rules factory based on action type
   const operationRules = (isSendAction: boolean): CompareRules => ({
-    // For send operations: add=non-breaking (can send new types), remove=breaking
-    // For receive operations: add=breaking (must handle new types), remove=non-breaking
-    $: isSendAction
-      ? [nonBreaking, breaking, unclassified]
-      : [breaking, nonBreaking, unclassified],
+    $: [nonBreaking, breaking, unclassified],
     [START_NEW_COMPARE_SCOPE_RULE]: isSendAction ? COMPARE_SCOPE_SEND : COMPARE_SCOPE_RECEIVE,
     '/title': { $: allAnnotation },
     '/summary': { $: allAnnotation },

--- a/src/asyncapi/asyncapi3.rules.ts
+++ b/src/asyncapi/asyncapi3.rules.ts
@@ -253,7 +253,7 @@ export const asyncApi3Rules = (options: AsyncApi3RulesOptions): CompareRules => 
 
   // Operation rules factory based on action type
   const operationRules = (isSendAction: boolean): CompareRules => ({
-    $: [nonBreaking, breaking, unclassified],
+    $: [unclassified, unclassified, unclassified],
     [START_NEW_COMPARE_SCOPE_RULE]: isSendAction ? COMPARE_SCOPE_SEND : COMPARE_SCOPE_RECEIVE,
     '/title': { $: allAnnotation },
     '/summary': { $: allAnnotation },
@@ -274,7 +274,7 @@ export const asyncApi3Rules = (options: AsyncApi3RulesOptions): CompareRules => 
       mapping: firstReferenceKeyMapping,
       '/*': {
         ...messageRules,
-        $: [nonBreaking, breaking, unclassified],
+        $: [unclassified, unclassified, unclassified],
         ignoreKeyDifference: true
       },
     },

--- a/test/asyncapi.diff.test.ts
+++ b/test/asyncapi.diff.test.ts
@@ -1,4 +1,4 @@
-import { apiDiff, CompareOptions, DiffAction, nonBreaking } from '../src'
+import { apiDiff, CompareOptions, DiffAction, unclassified } from '../src'
 import { parseAsyncApiAndAssertValid } from './helper/asyncapi'
 import { diffsMatcher } from './helper/matchers'
 
@@ -21,7 +21,7 @@ const operation = (operationId: string, action: 'send' | 'receive') => ({
 })
 
 describe('AsyncAPI diff — whole operations', () => {
-  it('classifies adding a send operation as non-breaking', async () => {
+  it('classifies adding a send operation as unclassified', async () => {
     const before = {
       asyncapi: '3.0.0',
       info: { title: 'Test', version: '1.0.0' },
@@ -47,13 +47,13 @@ describe('AsyncAPI diff — whole operations', () => {
     expect(diffs).toEqual(diffsMatcher([
       expect.objectContaining({
         action: DiffAction.add,
-        type: nonBreaking,
+        type: unclassified,
         afterDeclarationPaths: [['operations', 'op2']],
       }),
     ]))
   })
 
-  it('classifies adding a receive operation as non-breaking', async () => {
+  it('classifies adding a receive operation as unclassified', async () => {
     const before = {
       asyncapi: '3.0.0',
       info: { title: 'Test', version: '1.0.0' },
@@ -79,7 +79,7 @@ describe('AsyncAPI diff — whole operations', () => {
     expect(diffs).toEqual(diffsMatcher([
       expect.objectContaining({
         action: DiffAction.add,
-        type: nonBreaking,
+        type: unclassified,
         afterDeclarationPaths: [['operations', 'op2']],
       }),
     ]))

--- a/test/asyncapi.diff.test.ts
+++ b/test/asyncapi.diff.test.ts
@@ -1,4 +1,4 @@
-import { apiDiff, CompareOptions, DiffAction, unclassified } from '../src'
+import { apiDiff, CompareOptions, DiffAction, nonBreaking } from '../src'
 import { parseAsyncApiAndAssertValid } from './helper/asyncapi'
 import { diffsMatcher } from './helper/matchers'
 
@@ -21,7 +21,7 @@ const operation = (operationId: string, action: 'send' | 'receive') => ({
 })
 
 describe('AsyncAPI diff — whole operations', () => {
-  it('classifies adding a send operation as unclassified', async () => {
+  it('classifies adding a send operation as non-breaking', async () => {
     const before = {
       asyncapi: '3.0.0',
       info: { title: 'Test', version: '1.0.0' },
@@ -47,13 +47,13 @@ describe('AsyncAPI diff — whole operations', () => {
     expect(diffs).toEqual(diffsMatcher([
       expect.objectContaining({
         action: DiffAction.add,
-        type: unclassified,
+        type: nonBreaking,
         afterDeclarationPaths: [['operations', 'op2']],
       }),
     ]))
   })
 
-  it('classifies adding a receive operation as unclassified', async () => {
+  it('classifies adding a receive operation as non-breaking', async () => {
     const before = {
       asyncapi: '3.0.0',
       info: { title: 'Test', version: '1.0.0' },
@@ -79,7 +79,7 @@ describe('AsyncAPI diff — whole operations', () => {
     expect(diffs).toEqual(diffsMatcher([
       expect.objectContaining({
         action: DiffAction.add,
-        type: unclassified,
+        type: nonBreaking,
         afterDeclarationPaths: [['operations', 'op2']],
       }),
     ]))

--- a/test/asyncapi.diff.test.ts
+++ b/test/asyncapi.diff.test.ts
@@ -1,0 +1,87 @@
+import { apiDiff, CompareOptions, DiffAction, nonBreaking } from '../src'
+import { parseAsyncApiAndAssertValid } from './helper/asyncapi'
+import { diffsMatcher } from './helper/matchers'
+
+const TEST_COMPARE_OPTIONS: CompareOptions = {
+  unify: true,
+}
+
+const minimalChannel = {
+  ch: {
+    messages: { msg: { payload: { type: 'string' } } },
+  },
+}
+
+const operation = (operationId: string, action: 'send' | 'receive') => ({
+  [operationId]: {
+    action,
+    channel: { $ref: '#/channels/ch' },
+    messages: [{ $ref: '#/channels/ch/messages/msg' }],
+  },
+})
+
+describe('AsyncAPI diff — whole operations', () => {
+  it('classifies adding a send operation as non-breaking', async () => {
+    const before = {
+      asyncapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      channels: minimalChannel,
+      operations: operation('op1', 'send'),
+    }
+    const after = {
+      asyncapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      channels: minimalChannel,
+      operations: {
+        ...operation('op1', 'send'),
+        ...operation('op2', 'send'),
+      },
+    }
+
+    await parseAsyncApiAndAssertValid(before)
+    await parseAsyncApiAndAssertValid(after)
+
+    const { diffs } = apiDiff(before, after, TEST_COMPARE_OPTIONS)
+
+    expect(diffs.length).toBe(1)
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        type: nonBreaking,
+        afterDeclarationPaths: [['operations', 'op2']],
+      }),
+    ]))
+  })
+
+  it('classifies adding a receive operation as non-breaking', async () => {
+    const before = {
+      asyncapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      channels: minimalChannel,
+      operations: operation('op1', 'send'),
+    }
+    const after = {
+      asyncapi: '3.0.0',
+      info: { title: 'Test', version: '1.0.0' },
+      channels: minimalChannel,
+      operations: {
+        ...operation('op1', 'send'),
+        ...operation('op2', 'receive'),
+      },
+    }
+
+    await parseAsyncApiAndAssertValid(before)
+    await parseAsyncApiAndAssertValid(after)
+
+    const { diffs } = apiDiff(before, after, TEST_COMPARE_OPTIONS)
+
+    expect(diffs.length).toBe(1)
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.add,
+        type: nonBreaking,
+        afterDeclarationPaths: [['operations', 'op2']],
+      }),
+    ]))
+  })
+})


### PR DESCRIPTION
Changes are classified as [nonBreaking, breaking, unclassified] in any scope