### PR TITLE
fix: match combiner options by ref origins first, then by number of dangerous diffs

### DIFF
--- a/src/core/compare.ts
+++ b/src/core/compare.ts
@@ -542,15 +542,21 @@ function addNormalizedValuesToDenormalizedDiff(
 }
 
 export const compare = (before: unknown, after: unknown, options: InternalCompareOptions): CompareResult => {
+  // Ensure inlineRefsFlag is always set so combinersCompareResolver can use ref-based matching.
+  // If the caller already provides one we reuse it; otherwise we create an internal symbol.
+  const effectiveOptions: InternalCompareOptions = options.inlineRefsFlag
+    ? options
+    : { ...options, inlineRefsFlag: Symbol('inline-refs') }
+
   const beforeSpec = resolveSpec(before)
   const afterSpec = resolveSpec(after)
 
   const beforeFullyResolved = normalize(before, {
-    ...options,
+    ...effectiveOptions,
     source: options.beforeSource,
   })
   const afterFullyResolved = normalize(after, {
-    ...options,
+    ...effectiveOptions,
     source: options.afterSource,
   })
 
@@ -565,8 +571,8 @@ export const compare = (before: unknown, after: unknown, options: InternalCompar
 
   const rawDiffs: Diff[] = []
   const onDiff: DiffCallback = diff => rawDiffs.push(diff)
-  let merged = compareInternal(beforeFullyResolved, afterFullyResolved, onDiff, options)
-  if (options.normalizedResult) {
+  let merged = compareInternal(beforeFullyResolved, afterFullyResolved, onDiff, effectiveOptions)
+  if (effectiveOptions.normalizedResult) {
     return {
       diffs: rawDiffs,
       ownerDiffEntry: undefined,
@@ -584,10 +590,10 @@ export const compare = (before: unknown, after: unknown, options: InternalCompar
   // If before/after spec types differ, a single denormalization pass may only correctly interpret one side,
   // so we run it twice forcing each spec type to make diffs readable.
   if (beforeSpecType === afterSpecType) {
-    merged = denormalizeWithDiffsSave(merged, options)
+    merged = denormalizeWithDiffsSave(merged, effectiveOptions)
   } else {
     for (const forceRulesForSpecVersion of [beforeSpecType, afterSpecType]) {
-      merged = denormalizeWithDiffsSave(merged, { ...options, forceRulesForSpecVersion })
+      merged = denormalizeWithDiffsSave(merged, { ...effectiveOptions, forceRulesForSpecVersion })
     }
   }
 
@@ -600,8 +606,8 @@ export const compare = (before: unknown, after: unknown, options: InternalCompar
   addNormalizedValuesToDenormalizedDiff(
     denormalizedDiffs,
     rawDiffs,
-    options.beforeValueNormalizedProperty,
-    options.afterValueNormalizedProperty
+    effectiveOptions.beforeValueNormalizedProperty,
+    effectiveOptions.afterValueNormalizedProperty
   )
   return {
     diffs: denormalizedDiffs,

--- a/src/jsonSchema/jsonSchema.resolver.ts
+++ b/src/jsonSchema/jsonSchema.resolver.ts
@@ -3,12 +3,14 @@ import {
   addDiffObjectToContainer,
   ANY_COMBINER_INDEX,
   ANY_COMBINER_PATH,
+  breaking,
   createChildContext,
   diffFactory,
   getOrCreateChildDiffAdd,
   getOrCreateChildDiffRemove,
   nestedCompare,
   createDiffEntry,
+  risky,
 } from '../core'
 import type { CompareResolver, Diff, DiffEntry } from '../types'
 import { isArray, isObject, onlyExistedArrayIndexes } from '../utils'
@@ -81,10 +83,15 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
     }
   }
 
+  const dangerousSeverityCount = (diffs: Diff[]) =>
+    diffs.filter(d => d.type === breaking || d.type === risky).length
+
   comparedItems.sort((a, b) => {
-    const mainDiff = a.diffs.length - b.diffs.length
+    const dangerousSeverityDiff = dangerousSeverityCount(a.diffs) - dangerousSeverityCount(b.diffs)
+    if (dangerousSeverityDiff !== 0) { return dangerousSeverityDiff }
+    const totalDiff = a.diffs.length - b.diffs.length
     //reduce randomization when same diffs count
-    return mainDiff !== 0 ? mainDiff : Math.abs(a.before - a.after) - Math.abs(b.before - b.after)
+    return totalDiff !== 0 ? totalDiff : Math.abs(a.before - a.after) - Math.abs(b.before - b.after)
   })
 
   for (const compared of comparedItems) {

--- a/src/jsonSchema/jsonSchema.resolver.ts
+++ b/src/jsonSchema/jsonSchema.resolver.ts
@@ -37,8 +37,8 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
   // match combiners
   const beforeArrayIndexes = onlyExistedArrayIndexes(before.value)
   const afterArrayIndexes = onlyExistedArrayIndexes(after.value)
-  const beforeMatchedArrayIndexes = new Set<number>(beforeArrayIndexes)
-  const afterMatchedArrayIndexes = new Set<number>(afterArrayIndexes)
+  const beforeUnmatchedIndexes = new Set<number>(beforeArrayIndexes)
+  const afterUnmatchedIndexes = new Set<number>(afterArrayIndexes)
   const comparedItems = []
   const mergedCombinerJsoArray: unknown[] = []
   const diffs: Set<Diff> = new Set()
@@ -65,22 +65,22 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
   const { inlineRefsFlag } = options
   if (inlineRefsFlag) {
     for (const i of beforeArrayIndexes) {
-      if (!beforeMatchedArrayIndexes.has(i)) { continue }
+      if (!beforeUnmatchedIndexes.has(i)) { continue }
       const beforeItem = before.value[i]
       if (!isObject(beforeItem)) { continue }
       const beforeRefs = beforeItem[inlineRefsFlag] as string[] | undefined
       if (!beforeRefs?.length) { continue }
 
       for (const j of afterArrayIndexes) {
-        if (!afterMatchedArrayIndexes.has(j)) { continue }
+        if (!afterUnmatchedIndexes.has(j)) { continue }
         const afterItem = after.value[j]
         if (!isObject(afterItem)) { continue }
         const afterRefs = afterItem[inlineRefsFlag] as string[] | undefined
         if (!afterRefs?.length) { continue }
 
         if (haveCommonRef(beforeRefs, afterRefs)) {
-          beforeMatchedArrayIndexes.delete(i)
-          afterMatchedArrayIndexes.delete(j)
+          beforeUnmatchedIndexes.delete(i)
+          afterUnmatchedIndexes.delete(j)
           const { diffs: localDiffs, merged } = compareCombinerItems(beforeItem, afterItem)
           mergedCombinerJsoArray[j] = merged
           localDiffs.forEach(diff => diffs.add(diff))
@@ -92,17 +92,17 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
 
   // compare all combinations, find min diffs
   for (const i of beforeArrayIndexes) {
-    if (!beforeMatchedArrayIndexes.has(i)) { continue }
+    if (!beforeUnmatchedIndexes.has(i)) { continue }
     const beforeCombinerJso = before.value[i]
     for (const j of afterArrayIndexes) {
-      if (!afterMatchedArrayIndexes.has(j)) { continue }
+      if (!afterUnmatchedIndexes.has(j)) { continue }
       const afterCombinerJso = after.value[j]
 
       const { diffs: localDiffs, merged } = compareCombinerItems(beforeCombinerJso, afterCombinerJso)
 
       if (!localDiffs.length) {
-        afterMatchedArrayIndexes.delete(j)
-        beforeMatchedArrayIndexes.delete(i)
+        afterUnmatchedIndexes.delete(j)
+        beforeUnmatchedIndexes.delete(i)
         mergedCombinerJsoArray[j] = merged
         break
       }
@@ -127,14 +127,14 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
   })
 
   for (const compared of comparedItems) {
-    if (!afterMatchedArrayIndexes.has(compared.after) || !beforeMatchedArrayIndexes.has(compared.before)) { continue }
-    afterMatchedArrayIndexes.delete(compared.after)
-    beforeMatchedArrayIndexes.delete(compared.before)
+    if (!afterUnmatchedIndexes.has(compared.after) || !beforeUnmatchedIndexes.has(compared.before)) { continue }
+    afterUnmatchedIndexes.delete(compared.after)
+    beforeUnmatchedIndexes.delete(compared.before)
     mergedCombinerJsoArray[compared.after] = compared.merged
     compared.diffs.forEach(diff => diffs.add(diff))
   }
   const arrayMetaDiffEntries: DiffEntry<Diff>[] = []
-  for (const j of afterMatchedArrayIndexes.values()) {
+  for (const j of afterUnmatchedIndexes.values()) {
     mergedCombinerJsoArray[j] = after.value[j]
     const childCtx = createChildContext(ctx, j, undefined, j)
     const diffEntry = getOrCreateChildDiffAdd(options.diffUniquenessCache, childCtx)
@@ -153,7 +153,7 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
     }
   }
 
-  for (const i of beforeMatchedArrayIndexes.values()) {
+  for (const i of beforeUnmatchedIndexes.values()) {
     const safeInsertIndex = freeIndexesArray.shift()!/*length enough*/
     mergedCombinerJsoArray[safeInsertIndex] = before.value[i]
     const childCtx = createChildContext(ctx, safeInsertIndex, i, undefined)

--- a/src/jsonSchema/jsonSchema.resolver.ts
+++ b/src/jsonSchema/jsonSchema.resolver.ts
@@ -16,6 +16,11 @@ import type { CompareResolver, Diff, DiffEntry } from '../types'
 import { isArray, isObject, onlyExistedArrayIndexes } from '../utils'
 import { copyDescriptors } from '@netcracker/qubership-apihub-api-unifier'
 
+const haveCommonRef = (a: string[], b: string[]): boolean => {
+  const bSet = new Set(b)
+  return a.some(ref => bSet.has(ref))
+}
+
 export const combinersCompareResolver: CompareResolver = (ctx) => {
   const { before, after, options, scope } = ctx
   const { metaKey } = options
@@ -40,8 +45,44 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
 
   const rules = getNodeRules(ctx.rules, ANY_COMBINER_INDEX, ANY_COMBINER_PATH, before.value) || {}
 
+  // First pass: definitively match combiner options that share the same $ref origin.
+  // The assumption is that in real world cases if schema names are the same, then
+  // this is what we want to compare.
+  const { inlineRefsFlag } = options
+  if (inlineRefsFlag) {
+    for (const i of beforeArrayIndexes) {
+      if (!beforeMatchedArrayIndexes.has(i)) { continue }
+      const beforeItem = before.value[i]
+      if (!isObject(beforeItem)) { continue }
+      const beforeRefs = beforeItem[inlineRefsFlag] as string[] | undefined
+      if (!beforeRefs?.length) { continue }
+
+      for (const j of afterArrayIndexes) {
+        if (!afterMatchedArrayIndexes.has(j)) { continue }
+        const afterItem = after.value[j]
+        if (!isObject(afterItem)) { continue }
+        const afterRefs = afterItem[inlineRefsFlag] as string[] | undefined
+        if (!afterRefs?.length) { continue }
+
+        if (haveCommonRef(beforeRefs, afterRefs)) {
+          beforeMatchedArrayIndexes.delete(i)
+          afterMatchedArrayIndexes.delete(j)
+          const { diffs: localDiffs, merged } = nestedCompare(beforeItem, afterItem, {
+            ...options,
+            rules,
+            compareScope: ctx.scope,
+          })
+          mergedCombinerJsoArray[j] = merged
+          localDiffs.forEach(diff => diffs.add(diff))
+          break
+        }
+      }
+    }
+  }
+
   // compare all combinations, find min diffs
   for (const i of beforeArrayIndexes) {
+    if (!beforeMatchedArrayIndexes.has(i)) { continue }
     const beforeCombinerJso = before.value[i]
     for (const j of afterArrayIndexes) {
       if (!afterMatchedArrayIndexes.has(j)) { continue }

--- a/src/jsonSchema/jsonSchema.resolver.ts
+++ b/src/jsonSchema/jsonSchema.resolver.ts
@@ -45,6 +45,20 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
 
   const rules = getNodeRules(ctx.rules, ANY_COMBINER_INDEX, ANY_COMBINER_PATH, before.value) || {}
 
+  const compareCombinerItems = (beforeItem: unknown, afterItem: unknown) =>
+    ctx.options.mergedJsoCache.cacheEvaluationResultByFootprint(
+      [beforeItem, afterItem, scope],
+      ([b, a]) => nestedCompare(b, a, { ...options, rules, compareScope: ctx.scope }),
+      { diffs: [], ownerDiffEntry: undefined, merged: {} },
+      (result, guard) => {
+        guard.diffs.push(...result.diffs)
+        if (isObject(guard.merged) && isObject(result.merged))
+          guard.merged = copyDescriptors(guard.merged, result.merged)
+        else
+          guard.merged = result.merged
+        return guard
+      })
+
   // First pass: definitively match combiner options that share the same $ref origin.
   // The assumption is that in real world cases if schema names are the same, then
   // this is what we want to compare.
@@ -67,11 +81,7 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
         if (haveCommonRef(beforeRefs, afterRefs)) {
           beforeMatchedArrayIndexes.delete(i)
           afterMatchedArrayIndexes.delete(j)
-          const { diffs: localDiffs, merged } = nestedCompare(beforeItem, afterItem, {
-            ...options,
-            rules,
-            compareScope: ctx.scope,
-          })
+          const { diffs: localDiffs, merged } = compareCombinerItems(beforeItem, afterItem)
           mergedCombinerJsoArray[j] = merged
           localDiffs.forEach(diff => diffs.add(diff))
           break
@@ -88,26 +98,7 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
       if (!afterMatchedArrayIndexes.has(j)) { continue }
       const afterCombinerJso = after.value[j]
 
-      const {
-        diffs: localDiffs,
-        merged,
-      } = ctx.options.mergedJsoCache.cacheEvaluationResultByFootprint(
-        [beforeCombinerJso, afterCombinerJso, scope],
-        ([beforeCombinerJso, afterCombinerJso]) =>
-          nestedCompare(beforeCombinerJso, afterCombinerJso, {
-            ...options,
-            rules,
-            compareScope: ctx.scope,
-          }),
-        { diffs: [], ownerDiffEntry: undefined, merged: {} },
-        (result, guard) => {
-          guard.diffs.push(...result.diffs)
-          if (isObject(guard.merged) && isObject(result.merged))
-            guard.merged = copyDescriptors(guard.merged, result.merged)
-          else
-            guard.merged = result.merged
-          return guard
-        })
+      const { diffs: localDiffs, merged } = compareCombinerItems(beforeCombinerJso, afterCombinerJso)
 
       if (!localDiffs.length) {
         afterMatchedArrayIndexes.delete(j)

--- a/test/asyncapi.diff.test.ts
+++ b/test/asyncapi.diff.test.ts
@@ -1,4 +1,4 @@
-import { apiDiff, CompareOptions, DiffAction, nonBreaking } from '../src'
+import { apiDiff, breaking, CompareOptions, DiffAction, nonBreaking } from '../src'
 import { parseAsyncApiAndAssertValid } from './helper/asyncapi'
 import { diffsMatcher } from './helper/matchers'
 
@@ -83,5 +83,115 @@ describe('AsyncAPI diff — whole operations', () => {
         afterDeclarationPaths: [['operations', 'op2']],
       }),
     ]))
+  })
+})
+
+describe('AsyncAPI diff — combiner matching by ref origin', () => {
+  // SchemaA holds `type: string` and SchemaB holds `type: integer` in before.
+  // After swaps their content: SchemaA → integer, SchemaB → string.
+  // Without ref-based matching, content similarity would pair string↔string and
+  // integer↔integer, producing 0 diffs — an incorrect result.
+  // With ref-based matching, SchemaA is paired with SchemaA and SchemaB with SchemaB,
+  // correctly reporting a breaking type change inside each named component.
+
+  const makeSpec = (
+    schemaAType: string,
+    schemaBType: string,
+    oneOfRefs = ['#/components/schemas/SchemaA', '#/components/schemas/SchemaB'],
+  ) => ({
+    asyncapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    channels: {
+      myChannel: {
+        messages: {
+          myMessage: {
+            payload: {
+              oneOf: oneOfRefs.map($ref => ({ $ref })),
+            },
+          },
+        },
+      },
+    },
+    operations: {
+      op1: {
+        action: 'send' as const,
+        channel: { $ref: '#/channels/myChannel' },
+        messages: [{ $ref: '#/channels/myChannel/messages/myMessage' }],
+      },
+    },
+    components: {
+      schemas: {
+        SchemaA: { type: schemaAType },
+        SchemaB: { type: schemaBType },
+      },
+    },
+  })
+
+  const skipScopes = new Set(['components', 'root'])
+
+  it('detects type swap in oneOf message payload branches referenced by name', async () => {
+    const before = makeSpec('string', 'integer')
+    const after = makeSpec('integer', 'string')
+
+    await parseAsyncApiAndAssertValid(before)
+    await parseAsyncApiAndAssertValid(after)
+
+    const { diffs } = apiDiff(before, after, TEST_COMPARE_OPTIONS)
+
+    // Skip 'components' and 'root' scopes — they duplicate the send-scoped diffs
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.replace,
+        type: breaking,
+        beforeValue: 'string',
+        afterValue: 'integer',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        scope: 'send',
+      }),
+      expect.objectContaining({
+        action: DiffAction.replace,
+        type: breaking,
+        beforeValue: 'integer',
+        afterValue: 'string',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        scope: 'send',
+      }),
+    ], skipScopes))
+  })
+
+  it('keeps ref-origin matching when after oneOf message payload branches are reordered', async () => {
+    const before = makeSpec('string', 'integer')
+    const after = makeSpec('integer', 'string', [
+      '#/components/schemas/SchemaB',
+      '#/components/schemas/SchemaA',
+    ])
+
+    await parseAsyncApiAndAssertValid(before)
+    await parseAsyncApiAndAssertValid(after)
+
+    const { diffs } = apiDiff(before, after, TEST_COMPARE_OPTIONS)
+
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.replace,
+        type: breaking,
+        beforeValue: 'string',
+        afterValue: 'integer',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        scope: 'send',
+      }),
+      expect.objectContaining({
+        action: DiffAction.replace,
+        type: breaking,
+        beforeValue: 'integer',
+        afterValue: 'string',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        scope: 'send',
+      }),
+    ], skipScopes))
   })
 })

--- a/test/bugs.test.ts
+++ b/test/bugs.test.ts
@@ -353,4 +353,19 @@ describe('Real Data', () => {
 
     expect(merged).not.toHaveProperty(['paths', '/path1', 'put', 'responses', '200', 'content', 'application/json', 'schema', 'additionalProperties'])
   })
+
+  it('deleted property reported wrongly due to incorrect matching on options in combiner', () => {
+    const before = loadYamlSample('deleted-property-reported-wrongly/before.yaml')
+    const after = loadYamlSample('deleted-property-reported-wrongly/after.yaml')
+
+    const { diffs } = apiDiff(before, after, OPTIONS)
+
+    expect(diffs).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        action: DiffAction.remove,
+        beforeDeclarationPaths: [['components', 'schemas', 'QipDatafixCreateDto', 'properties', 'qipChain']],
+        type: breaking,
+      }),
+    ]))
+  })
 })

--- a/test/helper/resources/deleted-property-reported-wrongly/after.yaml
+++ b/test/helper/resources/deleted-property-reported-wrongly/after.yaml
@@ -1,0 +1,66 @@
+openapi: 3.1.0
+info:
+  title: Test sample
+  version: '1.0.0'
+paths:
+  /testPath:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/QipDatafixCreateDto'
+                - $ref: '#/components/schemas/RestCreateDto'
+        required: true
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    AuthorizationDto:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+    RestApiCallDto:
+      type: object
+      required:
+        - method
+        - url
+        - auth
+      properties:
+        method:
+          type: string
+        url:
+          type: string
+          pattern: \S
+        auth:
+          $ref: '#/components/schemas/AuthorizationDto'
+    ChainDto:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    QipDatafixCreateDto:
+      type: object
+      properties:
+        qipHttpTrigger:
+          type: object
+        qipChain:
+          $ref: '#/components/schemas/ChainDto'
+          type: object
+    RestCreateDto:
+      type: object
+      required:
+        - ticketExternalLink
+        - type
+      properties:
+        restApiCall:
+          type: object
+        ticketExternalLink:
+          type: string

--- a/test/helper/resources/deleted-property-reported-wrongly/before.yaml
+++ b/test/helper/resources/deleted-property-reported-wrongly/before.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.3
+info:
+  title: Test sample
+  version: '1.0.0'
+paths:
+  /testPath:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QipDatafixCreateDto'
+        required: true
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    AuthorizationDto:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+    RestApiCallDto:
+      type: object
+      required:
+        - method
+        - url
+        - auth
+      properties:
+        method:
+          type: string
+        url:
+          type: string
+          pattern: \S
+        auth:
+          $ref: '#/components/schemas/AuthorizationDto'
+    ChainDto:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    QipDatafixCreateDto:
+      type: object
+      properties:
+        qipHttpTrigger:
+          $ref: '#/components/schemas/RestApiCallDto'
+        qipChain:
+          $ref: '#/components/schemas/ChainDto'

--- a/test/json-schema.diff.test.ts
+++ b/test/json-schema.diff.test.ts
@@ -55,13 +55,13 @@ describe('JSON schema changes', () => {
         expect.objectContaining({
           action: DiffAction.add,
           afterValue: 'MyType',
-          afterDeclarationPaths: [['defs','MyType']],
+          afterDeclarationPaths: [['defs', 'MyType']],
         }),
         expect.objectContaining({
           action: DiffAction.replace,
           beforeValue: 'prop1',
           afterValue: 'MyType',
-          afterDeclarationPaths: [['defs','MyType']],
+          afterDeclarationPaths: [['defs', 'MyType']],
           beforeDeclarationPaths: [['properties', 'prop1']],
         }),
       ]))
@@ -119,7 +119,7 @@ describe('JSON schema changes', () => {
         beforeSource: beforeSource,
       })
 
-      
+
       expect(diffs.diffs).toEqual(diffsMatcher([
         expect.objectContaining({
           action: DiffAction.replace,
@@ -414,6 +414,117 @@ describe('JSON schema changes', () => {
         afterDeclarationPaths: [['enum', 1]],
       }),
     ]))
+  })
+
+  describe('combiner matching by inlineRefsFlag', () => {
+    // SchemaA holds `type: string` and SchemaB holds `type: integer` in before.
+    // After intentionally swaps the content: SchemaA → integer, SchemaB → string.
+    // The $ref names in the oneOf are unchanged, so the inlineRefsFlag paths match
+    // before[0]↔after[0] (both from SchemaA) and before[1]↔after[1] (both from SchemaB).
+    const beforeSource = {
+      defs: {
+        SchemaA: { type: 'string' },
+        SchemaB: { type: 'integer' },
+      },
+    }
+
+    const before = {
+      oneOf: [
+        { $ref: '#/defs/SchemaA' },
+        { $ref: '#/defs/SchemaB' },
+      ],
+    }
+
+    const afterSource = {
+      defs: {
+        SchemaA: { type: 'integer' },
+        SchemaB: { type: 'string' },
+      },
+    }
+
+    const after = {
+      oneOf: [
+        { $ref: '#/defs/SchemaA' },
+        { $ref: '#/defs/SchemaB' },
+      ],
+    }
+
+    const afterReordered = {
+      oneOf: [
+        { $ref: '#/defs/SchemaB' },
+        { $ref: '#/defs/SchemaA' },
+      ],
+    }
+
+    it('matches by ref origin and detects type swap inside named schemas', () => {
+      const result = apiDiff(before, after, {
+        inlineRefsFlag: TEST_INLINE_REF_FLAG,
+        beforeSource,
+        afterSource,
+      })
+
+      expect(result.diffs).toEqual(diffsMatcher([
+        expect.objectContaining({
+          action: DiffAction.replace,
+          beforeValue: 'string',
+          afterValue: 'integer',
+          beforeDeclarationPaths: [['defs', 'SchemaA', 'type']],
+          afterDeclarationPaths: [['defs', 'SchemaA', 'type']],
+        }),
+        expect.objectContaining({
+          action: DiffAction.replace,
+          beforeValue: 'integer',
+          afterValue: 'string',
+          beforeDeclarationPaths: [['defs', 'SchemaB', 'type']],
+          afterDeclarationPaths: [['defs', 'SchemaB', 'type']],
+        }),
+      ]))
+    })
+
+    it('without explicit inlineRefsFlag the internal flag still enables ref-based matching', () => {
+      // inlineRefsFlag is injected internally when not supplied, so the behaviour is the same.
+      const result = apiDiff(before, after, {
+        beforeSource,
+        afterSource,
+      })
+
+      expect(result.diffs).toEqual(diffsMatcher([
+        expect.objectContaining({
+          action: DiffAction.replace,
+          beforeValue: 'string',
+          afterValue: 'integer',
+        }),
+        expect.objectContaining({
+          action: DiffAction.replace,
+          beforeValue: 'integer',
+          afterValue: 'string',
+        }),
+      ]))
+    })
+
+    it('keeps ref-origin matching when after oneOf branches are reordered', () => {
+      const result = apiDiff(before, afterReordered, {
+        beforeSource,
+        afterSource,
+      })
+
+      expect(result.diffs).toEqual(diffsMatcher([
+        expect.objectContaining({
+          action: DiffAction.replace,
+          beforeValue: 'string',
+          afterValue: 'integer',
+          beforeDeclarationPaths: [['defs', 'SchemaA', 'type']],
+          afterDeclarationPaths: [['defs', 'SchemaA', 'type']],
+        }),
+        expect.objectContaining({
+          action: DiffAction.replace,
+          beforeValue: 'integer',
+          afterValue: 'string',
+          beforeDeclarationPaths: [['defs', 'SchemaB', 'type']],
+          afterDeclarationPaths: [['defs', 'SchemaB', 'type']],
+        }),
+      ]))
+    })
   })
 
   describe('diff in combiners', () => {

--- a/test/openapi.diff.test.ts
+++ b/test/openapi.diff.test.ts
@@ -274,3 +274,245 @@ describe('Openapi3 operation changes', () => {
   })
 
 })
+
+describe('Openapi3 combiner matching by ref origin', () => {
+  // SchemaA holds `type: string` and SchemaB holds `type: integer` in before.
+  // After swaps their content: SchemaA → integer, SchemaB → string.
+  // Without ref-based matching, content similarity would pair string↔string and
+  // integer↔integer across documents, producing 0 diffs — an incorrect result.
+  // With ref-based matching, SchemaA is paired with SchemaA and SchemaB with SchemaB,
+  // correctly reporting a type change inside each named component.
+  const beforeComponents = {
+    schemas: {
+      SchemaA: { type: 'string' },
+      SchemaB: { type: 'integer' },
+    },
+  }
+
+  const afterComponents = {
+    schemas: {
+      SchemaA: { type: 'integer' },
+      SchemaB: { type: 'string' },
+    },
+  }
+
+  const oneOfDirectOrder = () => [
+    { $ref: '#/components/schemas/SchemaA' },
+    { $ref: '#/components/schemas/SchemaB' },
+  ]
+
+  const oneOfReversedOrder = () => [
+    { $ref: '#/components/schemas/SchemaB' },
+    { $ref: '#/components/schemas/SchemaA' },
+  ]
+
+  const skipScopes = new Set(['components'])
+
+  it('detects type swap in oneOf response schema branches referenced by name', () => {
+    const before = {
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      oneOf: oneOfDirectOrder(),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: beforeComponents,
+    }
+
+    const after = {
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      oneOf: oneOfDirectOrder(),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: afterComponents,
+    }
+
+    const diffs = compareSpecs(before, after)
+    // Skip 'components' scope — its diffs duplicate the response-scoped ones
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeValue: 'string',
+        afterValue: 'integer',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        scope: 'response',
+      }),
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeValue: 'integer',
+        afterValue: 'string',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        scope: 'response',
+      }),
+    ], skipScopes))
+  })
+
+  it('detects type swap in oneOf request body schema branches referenced by name', () => {
+    const before = {
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    oneOf: oneOfDirectOrder(),
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+      components: beforeComponents,
+    }
+
+    const after = {
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    oneOf: oneOfDirectOrder(),
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+      components: afterComponents,
+    }
+
+    const diffs = compareSpecs(before, after)
+    // Skip 'components' scope — its diffs duplicate the request-scoped ones
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeValue: 'string',
+        afterValue: 'integer',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        scope: 'request',
+      }),
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeValue: 'integer',
+        afterValue: 'string',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        scope: 'request',
+      }),
+    ], skipScopes))
+  })
+
+  it('keeps ref-origin matching when after oneOf response schema branches are reordered', () => {
+    const before = {
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      oneOf: oneOfDirectOrder(),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: beforeComponents,
+    }
+
+    const after = {
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      oneOf: oneOfReversedOrder(),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: afterComponents,
+    }
+
+    const diffs = compareSpecs(before, after)
+    expect(diffs).toEqual(diffsMatcher([
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeValue: 'string',
+        afterValue: 'integer',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaA', 'type']],
+        scope: 'response',
+      }),
+      expect.objectContaining({
+        action: DiffAction.replace,
+        beforeValue: 'integer',
+        afterValue: 'string',
+        beforeDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        afterDeclarationPaths: [['components', 'schemas', 'SchemaB', 'type']],
+        scope: 'response',
+      }),
+    ], skipScopes))
+  })
+})


### PR DESCRIPTION
fix(compare): match combiner branches by shared $ref before similarity pairing

fix: prioritize combiner candidate matches with fewer breaking/risky diffs before total diff count