### PR TITLE
fix: match combiner branches by direct $ref origin instead of any transitive ref

### DIFF
--- a/src/jsonSchema/jsonSchema.resolver.ts
+++ b/src/jsonSchema/jsonSchema.resolver.ts
@@ -16,7 +16,7 @@ import type { CompareResolver, Diff, DiffEntry } from '../types'
 import { isArray, isObject, onlyExistedArrayIndexes } from '../utils'
 import { copyDescriptors } from '@netcracker/qubership-apihub-api-unifier'
 
-const haveSameDirectRef = (a: string[], b: string[]): boolean => {
+const haveSameLastRef = (a: string[], b: string[]): boolean => {
   // Compare last refs — these are the direct $ref targets at the current level.
   // Earlier entries are transitive refs from nested allOf inheritance and would
   // cause false matches between unrelated schemas sharing a common base.
@@ -61,7 +61,7 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
         return guard
       })
 
-  // First pass: definitively match combiner options that share the same $ref origin.
+  // First pass: definitively match combiner options that have the same last $ref.
   // The assumption is that in real world cases if schema names are the same, then
   // this is what we want to compare.
   const { inlineRefsFlag } = options
@@ -80,7 +80,7 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
         const afterRefs = afterItem[inlineRefsFlag] as string[] | undefined
         if (!afterRefs?.length) { continue }
 
-        if (haveSameDirectRef(beforeRefs, afterRefs)) {
+        if (haveSameLastRef(beforeRefs, afterRefs)) {
           beforeUnmatchedIndexes.delete(i)
           afterUnmatchedIndexes.delete(j)
           const { diffs: localDiffs, merged } = compareCombinerItems(beforeItem, afterItem)

--- a/src/jsonSchema/jsonSchema.resolver.ts
+++ b/src/jsonSchema/jsonSchema.resolver.ts
@@ -16,9 +16,11 @@ import type { CompareResolver, Diff, DiffEntry } from '../types'
 import { isArray, isObject, onlyExistedArrayIndexes } from '../utils'
 import { copyDescriptors } from '@netcracker/qubership-apihub-api-unifier'
 
-const haveCommonRef = (a: string[], b: string[]): boolean => {
-  const bSet = new Set(b)
-  return a.some(ref => bSet.has(ref))
+const haveSameDirectRef = (a: string[], b: string[]): boolean => {
+  // Compare last refs — these are the direct $ref targets at the current level.
+  // Earlier entries are transitive refs from nested allOf inheritance and would
+  // cause false matches between unrelated schemas sharing a common base.
+  return a.length > 0 && b.length > 0 && a[a.length - 1] === b[b.length - 1]
 }
 
 export const combinersCompareResolver: CompareResolver = (ctx) => {
@@ -78,7 +80,7 @@ export const combinersCompareResolver: CompareResolver = (ctx) => {
         const afterRefs = afterItem[inlineRefsFlag] as string[] | undefined
         if (!afterRefs?.length) { continue }
 
-        if (haveCommonRef(beforeRefs, afterRefs)) {
+        if (haveSameDirectRef(beforeRefs, afterRefs)) {
           beforeUnmatchedIndexes.delete(i)
           afterUnmatchedIndexes.delete(j)
           const { diffs: localDiffs, merged } = compareCombinerItems(beforeItem, afterItem)

--- a/test/openapi.diff.test.ts
+++ b/test/openapi.diff.test.ts
@@ -516,7 +516,7 @@ describe('Openapi3 combiner matching by ref origin', () => {
     ], skipScopes))
   })
 
-  it('should not report breaking changes when oneOf branches with allOf inheritance are reordered', () => {
+  it('should not report changes when oneOf branches with allOf inheritance are reordered', () => {
     const makeSpec = (oneOf: object[]) => ({
       openapi: '3.0.0',
       info: { version: '0.0.1', title: 'Test' },
@@ -541,7 +541,6 @@ describe('Openapi3 combiner matching by ref origin', () => {
     const after = makeSpec([{ $ref: '#/components/schemas/ChildB' }, { $ref: '#/components/schemas/ChildA' }])
 
     const diffs = compareSpecs(before, after)
-    const breakingDiffs = diffs.filter(d => d.type === breaking)
-    expect(breakingDiffs).toHaveLength(0)
+    expect(diffs).toHaveLength(0)
   })
 })

--- a/test/openapi.diff.test.ts
+++ b/test/openapi.diff.test.ts
@@ -515,4 +515,33 @@ describe('Openapi3 combiner matching by ref origin', () => {
       }),
     ], skipScopes))
   })
+
+  it('should not report breaking changes when oneOf branches with allOf inheritance are reordered', () => {
+    const makeSpec = (oneOf: object[]) => ({
+      openapi: '3.0.0',
+      info: { version: '0.0.1', title: 'Test' },
+      paths: {
+        '/test': {
+          post: {
+            requestBody: { content: { 'application/json': { schema: { oneOf } } } },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Base: { type: 'object', properties: { id: { type: 'string' } } },
+          ChildA: { allOf: [{ $ref: '#/components/schemas/Base' }, { type: 'object', properties: { fieldA: { type: 'string' } } }] },
+          ChildB: { allOf: [{ $ref: '#/components/schemas/Base' }, { type: 'object', properties: { fieldB: { type: 'string' } } }] },
+        },
+      },
+    })
+
+    const before = makeSpec([{ $ref: '#/components/schemas/ChildA' }, { $ref: '#/components/schemas/ChildB' }])
+    const after = makeSpec([{ $ref: '#/components/schemas/ChildB' }, { $ref: '#/components/schemas/ChildA' }])
+
+    const diffs = compareSpecs(before, after)
+    const breakingDiffs = diffs.filter(d => d.type === breaking)
+    expect(breakingDiffs).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## Summary
  
  When `oneOf` branches reference schemas that inherit from a common base via `allOf`, reordering those branches falsely reports breaking changes (deleted/added properties).

  **Root cause:** `combinersCompareResolver` matches `oneOf` items by shared `$ref` origins using `inlineRefsFlag`. The `inlineRefsFlag` array accumulates refs from all resolution levels — both the direct `$ref` (e.g. `ChildA`) and transitive refs from nested `allOf` (e.g. `Base`). The old `haveCommonRef`
  matched on *any* shared ref, so `ChildA` and `ChildB` would incorrectly match through their common `Base`.                                                                                                                                                                                     

  **Fix:** Compare only the last element of the `inlineRefsFlag` array — the last `$ref` target at the current level. The unifier's `addRefInlineHistory` always appends refs in resolution order (inner → outer), so the last entry is the ref to the actual schema definition.

  **Before:** `ChildA ↔ ChildB` matched via shared `Base` → 8 false breaking + 8 false non-breaking changes
  **After:** `ChildA ↔ ChildA`, `ChildB ↔ ChildB` matched by direct ref → 0 breaking changes

  - Renamed `haveCommonRef` → `haveSameLastRef` to reflect the new semantics
  - All 6330 existing tests pass
