### PR TITLE
refactor(test): import ddlapi parser from /parser; use bundler moduleResolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
       },
       "devDependencies": {
         "@asyncapi/parser": "3.4.0",
-        "@netcracker/qubership-apihub-compatibility-suites": "2.6.0",
-        "@netcracker/qubership-apihub-graphapi": "1.0.10",
+        "@netcracker/qubership-apihub-compatibility-suites": "dev",
+        "@netcracker/qubership-apihub-graphapi": "dev",
         "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
         "@types/jest": "30.0.0",
         "@types/node": "25.0.3",
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-api-unifier": {
-      "version": "2.8.1-feature-ddl.20260609115605",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-unifier/2.8.1-feature-ddl.20260609115605/48a77e64e7eeb964ee5e11d75d985d0e3c9ebca0",
-      "integrity": "sha512-33jWQeiVLV6Rvt94x7FEfjzPl4JMe290am2acOhFcsfSfIyoRWHGpoFghS7+F69SB1iqIPssiuRnqHeJLvLaTQ==",
+      "version": "2.8.1-feature-ddl.20260701154145",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-unifier/2.8.1-feature-ddl.20260701154145/112bcea898d5c9ceec2caa39192c314971edd143",
+      "integrity": "sha512-mvJ8u/mCH/nSMjh98snfnKJ1Omsv12/K585tG1DcQFDYPOsCJaG/0AlVe0S8miPlST35SO4p82MzlFGltYuRAg==",
       "dependencies": {
         "@netcracker/qubership-apihub-ddlapi": "feature-ddl",
         "@netcracker/qubership-apihub-json-crawl": "1.2.1",
@@ -2211,26 +2211,27 @@
       "license": "MIT"
     },
     "node_modules/@netcracker/qubership-apihub-compatibility-suites": {
-      "version": "2.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-compatibility-suites/2.6.0/b41a30fd8e270412bc14a3fce92d674002bb0cad",
-      "integrity": "sha512-nDQcwyMtYQSUpNglT14hrHt+pjQaItX0dVlLX/CA9Ykb2FBB/AN8WOGzeAM/LLJp/UrHqZt4ZtKoQptqwzbSRQ==",
+      "version": "2.6.1-dev.20260623151734",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-compatibility-suites/2.6.1-dev.20260623151734/5c622f263d88e3c79e1f508f6d3f24683a6e3d96",
+      "integrity": "sha512-nJnNP3FtilGBqR7XY7kfpIxzbHZ+3343LimRoh3nSILP1eBHZprav23dCRpoxf+851Y5ibNvmNdp8gRG/kfiJQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@netcracker/qubership-apihub-ddlapi": {
-      "version": "0.1.0-feature-ddl.20260609115217",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-ddlapi/0.1.0-feature-ddl.20260609115217/80c6c6ff908539cdeedef9dbea612df7579fedbe",
-      "integrity": "sha512-6CsDY5GFfGeqvbHU+tjxjIVdtYXgWjhQiH5He5XvLNGyThhAo+JZn1HRenRyAnQnMzzRuX92SI6L+BLQCrCimA==",
+      "version": "1.0.0-feature-ddl.20260701153302",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-ddlapi/1.0.0-feature-ddl.20260701153302/e83d626fd81e4c149dc86ad2ed8efa4a818fe8a0",
+      "integrity": "sha512-9R4vEgcMR4VKYSDSinAUX7YR/YRNgmvN3SrBHVIAfJyctfZzjxIFG/SR85tuJldi6HOKoklaJcH1hpf5SFuIlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pgsql/types": "^17.6.2",
-        "pgsql-parser": "^17.9.15"
+        "@pgsql/types": "17.6.2",
+        "libpg-query": "17.7.3",
+        "pgsql-deparser": "17.18.3"
       }
     },
     "node_modules/@netcracker/qubership-apihub-graphapi": {
-      "version": "1.0.10",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-graphapi/1.0.10/5ae05732e753fa2764af008dd7a837029a7e5822",
-      "integrity": "sha512-sHGPNujgLmez2Ct/4P1HYo7Ph/w/3RluP3sJ+fn1H1z6VuDwBf9FOBk2PzwHfqIcOiO4/TuGNat0E5t6wDrqwQ==",
+      "version": "1.0.11-dev.20260623145927",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-graphapi/1.0.11-dev.20260623145927/0f9119f881b41556e94815f64e390fbf1f095324",
+      "integrity": "sha512-dVRkVQ5rROz5ZN4hNjOSuVslBGQKeEGrkJhswsXzt1usAD+VaO4lCfDGafMDnJDCkGNmVzT00OjJ5z3TqgD28w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0"
@@ -9218,17 +9219,6 @@
       "dependencies": {
         "@pgsql/quotes": "17.1.0",
         "@pgsql/types": "^17.6.2"
-      }
-    },
-    "node_modules/pgsql-parser": {
-      "version": "17.9.15",
-      "resolved": "https://registry.npmjs.org/pgsql-parser/-/pgsql-parser-17.9.15.tgz",
-      "integrity": "sha512-6+k0EtTn0CEQTR5v2APARu9En4vm46TpmpdMSfKDHkZwWZuEc08B7SeVg32VxNQ2HD5xk+dQ9TD0k9m+S+vFgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@pgsql/types": "^17.6.2",
-        "libpg-query": "17.7.3",
-        "pgsql-deparser": "17.18.3"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-api-unifier": "feature-externalize-pqparser",
-    "@netcracker/qubership-apihub-ddlapi": "feature-externalize-pqparser",
+    "@netcracker/qubership-apihub-api-unifier": "feature-ddl",
+    "@netcracker/qubership-apihub-ddlapi": "feature-ddl",
     "@netcracker/qubership-apihub-json-crawl": "1.2.1",
     "fast-equals": "6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-api-unifier": "feature-ddl",
-    "@netcracker/qubership-apihub-ddlapi": "feature-ddl",
+    "@netcracker/qubership-apihub-api-unifier": "feature-externalize-pqparser",
+    "@netcracker/qubership-apihub-ddlapi": "feature-externalize-pqparser",
     "@netcracker/qubership-apihub-json-crawl": "1.2.1",
     "fast-equals": "6.0.0"
   },

--- a/test/ddl.setup.test.ts
+++ b/test/ddl.setup.test.ts
@@ -1,4 +1,4 @@
-import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi/parser'
 import {
   DDL_API_NORMALIZE_OPTIONS,
   resolveSpec,

--- a/test/helper/ddl.ts
+++ b/test/helper/ddl.ts
@@ -1,4 +1,4 @@
-import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi'
+import { buildFromDdl } from '@netcracker/qubership-apihub-ddlapi/parser'
 import { apiDiff } from '../../src'
 import { CompareOptions, CompareResult } from '../../src/types'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */


### PR DESCRIPTION
api-diff's src only uses the ddlapi model vocabulary, which stays on the package root. The two test files that parse DDL now import buildFromDdl from '@netcracker/qubership-apihub-ddlapi/parser'.

Switch moduleResolution "node" -> "bundler" so TypeScript honors the package `exports` map and resolves the '/parser' subpath, matching how Vite/Rollup bundle the package.